### PR TITLE
Update grex.sh to run task set properly over ssh

### DIFF
--- a/grex.sh
+++ b/grex.sh
@@ -324,6 +324,7 @@ function t1_cmd() {
 function t2_cmd() {
   Os:require "poetry" "pipx install poetry"
   Os:require "taskset" "util-linux"
+  export PATH="$HOME/.local/bin:$PATH"
   echo -e "cd $t2_path; taskset -c 10-14 poetry run startT2 --outroot $t2_cand_path --db-path $db_path"
 }
 


### PR DESCRIPTION
Taskset doesn't use the same file for accessing `PATH` when run over ssh rather than directly on the machine. This causes it to not see `poetry` when starting T2, causing the startup to fail. I added a line that explicitly adds the parent directory for `poetry` (export PATH="$HOME/.local/bin:$PATH") in the t2_cmd function, which fix the issue with starting up grex over ssh.