### PR TITLE
Update grex.sh to export `~/.local/bin` in t2_cmd

### DIFF
--- a/grex.sh
+++ b/grex.sh
@@ -324,7 +324,7 @@ function t1_cmd() {
 function t2_cmd() {
   Os:require "poetry" "pipx install poetry"
   Os:require "taskset" "util-linux"
-  echo -e "cd $t2_path; taskset -c 10-14 poetry run startT2 --outroot $t2_cand_path --db-path $db_path"
+  echo -e "export PATH="$HOME/.local/bin:$PATH"; cd $t2_path; taskset -c 10-14 poetry run startT2 --outroot $t2_cand_path --db-path $db_path"
 }
 
 #####################################################################


### PR DESCRIPTION
Change from previous PR because the `export PATH` bit was exterior to `echo`, making it useless. The goal of the PR is to make sure that `~/.local/bin` is available to any subshells the command string runs in so that `poetry` is on the `PATH`. This should address a issue I've had where running grex over ssh terminates when trying to run poetry for T2.